### PR TITLE
Add stdout and stderr formatter.

### DIFF
--- a/src/fmt.ml
+++ b/src/fmt.ml
@@ -178,6 +178,11 @@ let styled style pp_v ppf = match style_tags () with
 
 let styled_string style = styled style string
 
+(* Formatters *)
+
+let stdout = Format.std_formatter
+let stderr = Format.err_formatter
+
 (*---------------------------------------------------------------------------
    Copyright 2014 Daniel C. Bünzli.
    All rights reserved.

--- a/src/fmt.mli
+++ b/src/fmt.mli
@@ -203,6 +203,15 @@ val set_style_tags : style_tags -> unit
 (** [set_style_tags s] sets the current tag style used by
       {!Fmt.pp_styled}. *)
 
+
+(** {1:fmt Standard output formatters} *)
+
+val stdout : Format.formatter
+(** Standard output formatter. *)
+
+val stderr : Format.formatter
+(** Standard error formatter. *)
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2014 Daniel C. Bünzli.
    All rights reserved.


### PR DESCRIPTION
I feel like more functions on formatters could be added (the stdlib is severly lacking in this domain ..)

If you have a better idea for the naming, I'm all for it. The fact that both the printers and the output channels are called formatters in the stdlib is extremly confusing.