### PR TITLE
Relax Fmt.(invalid_arg, failwith) type signature

### DIFF
--- a/src/fmt.mli
+++ b/src/fmt.mli
@@ -62,11 +62,11 @@ val epr : ('a, Format.formatter, unit) format -> 'a
 
 (** {1:fmt_exns Formatting exceptions} *)
 
-val failwith : ('a, Format.formatter, unit, unit) format4 -> 'a
+val failwith : ('a, Format.formatter, unit, 'b) format4 -> 'a
 (** [failwith] is [kstrf failwith], raises {!Pervasives.Failure} with
     a pretty-printed string argument. *)
 
-val invalid_arg : ('a, Format.formatter, unit, unit) format4 -> 'a
+val invalid_arg : ('a, Format.formatter, unit, 'b) format4 -> 'a
 (** [invalid_arg] is [kstrf invalid_arg], raises
     {!Pervasives.Invalid_argument} with a pretty-printed string argument. *)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -45,6 +45,11 @@ let test_style_renderer () =
   assert (Fmt.style_renderer ppf = `None);
   ()
 
+let test_exn_typechecks () =
+  let (_ : bool) = true || Fmt.failwith "%s" "" in
+  let (_ : bool) = true || Fmt.invalid_arg "%s" "" in
+  ()
+
 let tests () =
   test_exn_backtrace ();
   test_dump_uchar ();


### PR DESCRIPTION
Fixes 310dcdce6d83ee5ef1f043c8e6c322d04b900a64 which included an
overly-restrictive definition of the function types.

Add a small test to make sure the types are properly relaxed.