### PR TITLE
Change signal function

### DIFF
--- a/src/fmt.ml
+++ b/src/fmt.ml
@@ -141,29 +141,18 @@ let using f pp ppf v = pp ppf (f v)
 
 module Dump = struct
 
-  let signal ppf s = match s with
-  | s when s = Sys.sigabrt -> string ppf "SIGABRT"
-  | s when s = Sys.sigalrm -> string ppf "SIGALRM"
-  | s when s = Sys.sigfpe -> string ppf "SIGFPE"
-  | s when s = Sys.sighup -> string ppf "SIGHUP"
-  | s when s = Sys.sigill -> string ppf "SIGILL"
-  | s when s = Sys.sigint -> string ppf "SIGINT"
-  | s when s = Sys.sigkill -> string ppf "SIGKILL"
-  | s when s = Sys.sigpipe -> string ppf "SIGPIPE"
-  | s when s = Sys.sigquit -> string ppf "SIGQUIT"
-  | s when s = Sys.sigsegv -> string ppf "SIGSEGV"
-  | s when s = Sys.sigterm -> string ppf "SIGTERM"
-  | s when s = Sys.sigusr1 -> string ppf "SIGUSR1"
-  | s when s = Sys.sigusr2 -> string ppf "SIGUSR2"
-  | s when s = Sys.sigchld -> string ppf "SIGCHLD"
-  | s when s = Sys.sigcont -> string ppf "SIGCONT"
-  | s when s = Sys.sigstop -> string ppf "SIGSTOP"
-  | s when s = Sys.sigtstp -> string ppf "SIGTSTP"
-  | s when s = Sys.sigttin -> string ppf "SIGTTIN"
-  | s when s = Sys.sigttou -> string ppf "SIGTTOU"
-  | s when s = Sys.sigvtalrm -> string ppf "SIGVTALRM"
-  | s when s = Sys.sigprof -> string ppf "SIGPROF"
-  | unknown -> pf ppf "SIG(%d)" unknown
+  let signal ppf s =
+    let signals = [|
+        "SIGABRT"; "SIGALRM"; "SIGFPE"; "SIGHUP"; "SIGILL";
+        "SIGINT"; "SIGKILL"; "SIGPIPE"; "SIGQUIT"; "SIGSEGV";
+        "SIGTERM"; "SIGUSR1"; "SIGUSR2"; "SIGCHLD"; "SIGCONT";
+        "SIGSTOP"; "SIGTSTP"; "SIGTTIN"; "SIGTTOU"; "SIGVTALRM";
+        "SIGPROF"; "SIGBUS"; "SIGPOLL"; "SIGSYS"; "SIGTRAP";
+        "SIGURG"; "SIGXCPU"; "SIGXFSZ"
+      |]
+    in
+    if s >= -28 && s <= -1 then string ppf signals.(-s -1)
+    else pf ppf "SIG(%d)" s
 
   let uchar ppf u = pf ppf "U+%04X" (Uchar.to_int u)
 


### PR DESCRIPTION
This change replaces the pattern-matching in the signal function by a an array access for a better complexity.
It also adds the "SIGBUS"; "SIGPOLL"; "SIGSYS"; "SIGTRAP";  "SIGURG"; "SIGXCPU"; "SIGXFSZ" signals which were added in  https://github.com/ocaml/ocaml/commit/a3041d95508a6bdcd9477983cf33725eaf208974#diff-1e0d7b30cd49fac46cc6737320356c75