### PR TITLE
Formatters for 'a Seq.t

### DIFF
--- a/opam
+++ b/opam
@@ -16,6 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}
   "result"
+  "seq"
   "uchar"
 ]
 depopts: [ "base-unix" "cmdliner" ]

--- a/src/fmt.ml
+++ b/src/fmt.ml
@@ -133,6 +133,7 @@ let iter_bindings ?sep:(pp_sep = cut) iter pp_binding ppf v =
 
 let list ?sep pp_elt = iter ?sep List.iter pp_elt
 let array ?sep pp_elt = iter ?sep Array.iter pp_elt
+let seq ?sep pp_elt = iter ?sep Seq.iter pp_elt
 let hashtbl ?sep pp_binding = iter_bindings ?sep Hashtbl.iter pp_binding
 let queue ?sep pp_elt = iter Queue.iter pp_elt
 let stack ?sep pp_elt = iter Stack.iter pp_elt
@@ -194,6 +195,16 @@ module Dump = struct
       pf ppf ";@ @[%a@]" pp_elt a.(i)
     done;
     pf ppf "|]@]"
+
+  let seq pp_elt ppf s =
+    let rec loop = function
+    | Seq.Nil -> ()
+    | Seq.Cons(v, vs) ->
+        match vs () with
+        | Seq.Nil -> pf ppf "@[%a@]" pp_elt v
+        | Seq.Cons(_) as next -> pf ppf "@[%a@];@ " pp_elt v; loop next
+    in
+    pf ppf "@[<1>["; loop (s ()); pf ppf "]@]"
 
   let iter iter pp_name pp_elt ppf v =
     let is_first = ref true in

--- a/src/fmt.mli
+++ b/src/fmt.mli
@@ -195,6 +195,11 @@ val array : ?sep:unit t -> 'a t -> 'a array t
     is formatted in order with [pp_v]. Elements are separated by [sep]
     (defaults to {!cut}). If the array is empty, this is {!nop}. *)
 
+val seq : ?sep:unit t -> 'a t -> 'a Seq.t t
+(** [seq sep pp_v] formats sequence elements. Each element of the sequence
+    is formatted in order with [pp_v]. Elements are separated by [sep]
+    (defaults to {!cut}). If the sequence is empty, this is {!nop}. *)
+
 val hashtbl : ?sep:unit t -> ('a * 'b) t -> ('a, 'b) Hashtbl.t t
 (** [hashtbl ~sep pp_binding] formats the bindings of a hash
     table. Each binding is formatted with [pp_binding] and bindings
@@ -271,6 +276,10 @@ module Dump : sig
 
   val array : 'a t -> 'a array t
   (** [array pp_v] formats an OCaml array using [pp_v] for the array
+      elements. *)
+
+  val seq : 'a t -> 'a Seq.t t
+  (** [seq pp_v] formats an OCaml sequence using [pp_v] for the sequence
       elements. *)
 
   val hashtbl : 'a t -> 'b t -> ('a, 'b) Hashtbl.t t


### PR DESCRIPTION
The opam seq package will pull in a compatibility library for OCaml
versions before 4.07.0.

This follows the formatting of lists for `Fmt.Dump.seq`.