### PR TITLE
Fix typo in [int] doc

### DIFF
--- a/src/fmt.mli
+++ b/src/fmt.mli
@@ -207,7 +207,7 @@ val bool : bool t
 (** [bool] is {!Format.pp_print_bool}. *)
 
 val int : int t
-(** [int] is [pf ppf "%d"]. *)
+(** [int ppf] is [pf ppf "%d"]. *)
 
 val nativeint : nativeint t
 (** [nativeint ppf] is [pf ppf "%nd"]. *)


### PR DESCRIPTION
`int` -> `int ppf`