### PR TITLE
Use open type for error_msg result

### DIFF
--- a/src/fmt.mli
+++ b/src/fmt.mli
@@ -72,7 +72,7 @@ val error : ('b, Format.formatter , unit, ('a, string) result) format4 -> 'b
 (** [error fmt ...] is [kstr (fun s -> Error s) fmt ...] *)
 
 val error_msg :
-  ('b, Format.formatter , unit, ('a, [`Msg of string]) result) format4 -> 'b
+  ('b, Format.formatter , unit, ('a, [> `Msg of string]) result) format4 -> 'b
 (** [error_msg fmt ...] is [kstr (fun s -> Error (`Msg s)) fmt ...] *)
 
 (** {1 Formatters} *)


### PR DESCRIPTION
This makes it easy to combine with other errors. e.g.

```ocaml
if cancelled then Error `Cancelled
else Fmt.error_msg "Failed"
```