### PR TITLE
Dump: fix dumping of sequences

### DIFF
--- a/src/fmt.ml
+++ b/src/fmt.ml
@@ -170,16 +170,6 @@ let stack ?sep pp_elt = iter Stack.iter pp_elt
 
 module Dump = struct
 
-  (* Sequencing *)
-
-  let iter iter_f pp_name pp_elt =
-    let pp_v = iter ~sep:sp iter_f (box pp_elt) in
-    parens (pp_name ++ sp ++ pp_v)
-
-  let iter_bindings iter_f pp_name pp_k pp_v =
-    let pp_v = iter_bindings ~sep:sp iter_f (pair pp_k pp_v) in
-    parens (pp_name ++ sp ++ pp_v)
-
   (* Stlib types *)
 
   let sig_names =
@@ -210,6 +200,18 @@ module Dump = struct
   let result ~ok ~error ppf = function
   | Ok v -> pf ppf "@[<2>Ok@ @[%a@]@]" ok v
   | Error e -> pf ppf "@[<2>Error@ @[%a@]@]" error e
+
+  (* Sequencing *)
+
+  let iter iter_f pp_name pp_elt =
+    let pp_v = iter ~sep:sp iter_f (box pp_elt) in
+    parens (pp_name ++ sp ++ pp_v)
+
+  let iter_bindings iter_f pp_name pp_k pp_v =
+    let pp_v = iter_bindings ~sep:sp iter_f (pair pp_k pp_v) in
+    parens (pp_name ++ sp ++ pp_v)
+
+  (* Stdlib data structures *)
 
   let list pp_elt = brackets (list ~sep:semi (box pp_elt))
   let array pp_elt = oxford_brackets (array ~sep:semi (box pp_elt))


### PR DESCRIPTION
Fix regression introduced in Fmt.0.8.7, where Dump.hashtbl prints no separators anymore:
```
utop # let h = Hashtbl.create 47 in Hashtbl.add h 1 2; Hashtbl.add h 3 4; Fmt.to_to_string (Fmt.Dump.hashtbl Fmt.int Fmt.int) h;;
- : string = "(hashtbl 34 12)"
```

Prior to fmt.0.8.7 it used to print separators between keys and values
which is more useful:
```
- : string = "(hashtbl (3, 4)(1, 2))"
```

Move code around, so that we use the definition of `pair` from `Dump`,
which adds the proper separators.