### PR TITLE
Add the [@@ocaml.deprecated] annotation to deprecated functions.

### DIFF
--- a/src/fmt.mli
+++ b/src/fmt.mli
@@ -624,30 +624,38 @@ val to_to_string : 'a t -> 'a -> string
 (** {1:deprecated Deprecated} *)
 
 val strf : ('a, Format.formatter, unit, string) format4 -> 'a
+[@@ocaml.deprecated]
 (** @deprecated use {!str} instead. *)
 
 val kstrf : (string -> 'a) -> ('b, Format.formatter, unit, 'a) format4 -> 'b
+[@@ocaml.deprecated]
 (** @deprecated use {!kstr} instead. *)
 
 val strf_like :
   Format.formatter -> ('a, Format.formatter, unit, string) format4 -> 'a
+[@@ocaml.deprecated]
 (** @deprecated use {!str_like} instead. *)
 
 val always : (unit, Format.formatter, unit) Stdlib.format -> 'a t
+[@@ocaml.deprecated]
 (** @deprecated use {!any} instead. *)
 
 val unit : (unit, Format.formatter, unit) Stdlib.format -> unit t
+[@@ocaml.deprecated]
 (** @deprecated use {!any}. *)
 
 val prefix : unit t -> 'a t -> 'a t
+[@@ocaml.deprecated]
 (** @deprecated use {!( ++ )}. *)
 
 val suffix : unit t -> 'a t -> 'a t
+[@@ocaml.deprecated]
 (** @deprecated use {!( ++ )}. *)
 
 val styled_unit :
   style -> (unit, Format.formatter, unit) Stdlib.format -> unit t
-(** @deprecated, use [styled s (any fmt)] instead *)
+[@@ocaml.deprecated]
+(** @deprecated use [styled s (any fmt)] instead *)
 
 (** {1:nameconv Naming conventions}
 


### PR DESCRIPTION
Hi!
This tags deprecated functions with the `ocaml.deprecated` compiler annotation, so that an error or a warning may be raised at compile-time if a project uses these functions.
Do you prefer `ocaml.deprecated` or `alert deprecated`? See https://caml.inria.fr/pub/docs/manual-ocaml/alerts.html.