### PR TITLE
Use Toploop.load_file for 4.14.0+trunk

### DIFF
--- a/src/fmt_top.ml
+++ b/src/fmt_top.ml
@@ -4,7 +4,7 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
-let () = ignore (Toploop.use_file Format.err_formatter "fmt_tty_top_init.ml")
+let () = ignore (Toploop.load_file Format.err_formatter "fmt_tty_top_init.ml")
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2015 The fmt programmers


### PR DESCRIPTION
4.14.0+trunk has deprecated `Toploop.use_file` and we now need to use `Toploop.load_file`.